### PR TITLE
removing iwgetid dependency and several little fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ A wifi menu for i3/openbox/etc. written in bash. Uses rofi and nmcli.
 
 * nmcli
 * iw
-* wireless_tools
 * rofi ( _I may end up expanding compatibility to dmenu_ )
 * bash ( _but you probably already knew that_ )
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ A wifi menu for i3/openbox/etc. written in bash. Uses rofi and nmcli.
 #### _Optional_
 
 * lemonbar (or some other bar, i.e. tint2)
-* openbox/i3/etc. 
+* openbox/i3/etc.
 
 ### Installation
-* make sure you have all the dependencies installed 
+* make sure you have all the dependencies installed
 
 * run the following commands in your terminal. Replace uppercase variables with personal choice
 ```
@@ -53,7 +53,7 @@ sh "./rofi-wifi-menu.sh"
 ### Configuration
 rofi-wifi-menu has an example configuration file in the repository. It will run without it, but will warn you if it does not exist.
 
-To configure rofi-wifi-menu, first cd into the directory it is installed into. Then edit the file `config.example`. 
+To configure rofi-wifi-menu, first cd into the directory it is installed into. Then edit the file `config.example`.
 It should contain the following variables:
 * position
 * y-offset
@@ -63,17 +63,17 @@ It should contain the following variables:
 #### position
 position can be configured where the number represents the position on this screen in this way
 
-| *Screen* | Left | Right | Center |
-|---|---|---|---|
-| **Top** | 1 | 2 | 3 |
-| **Center** | 8 | 0 | 4 |
-| **Bottom** | 7 | 6 | 5 |
+| *Screen*   | Left | Right | Center |
+|------------|------|-------|--------|
+| **Top**    | 1    | 2     | 3      |
+| **Center** | 8    | 0     | 4      |
+| **Bottom** | 7    | 6     | 5      |
 
 #### y-offset
 
 y-offset is measured in pixels. A positive value moves the window downward, while a negative value moves it upward.
 
-#### x-offset 
+#### x-offset
 
 x-offset is measured in pixels. A positive value move the window rightward, while a negative value moves it leftward.
 

--- a/config.example
+++ b/config.example
@@ -1,9 +1,9 @@
 # Config for rofi-wifi-menu
 
-# position values: 
+# position values:
 # 1 2 3
 # 8 0 4
-# 7 6 5 
+# 7 6 5
 POSITION=3
 
 #y-offset

--- a/rofi-wifi-menu.sh
+++ b/rofi-wifi-menu.sh
@@ -50,19 +50,11 @@ elif [[ "$CONSTATE" =~ "disabled" ]]; then
 	TOGGLE="toggle on"
 fi
 
-eval FIELDSARR=( $(cat ./config | awk 'BEGIN { FS=","; OFS="\n" } /^FIELDS/ { $1 = substr($1, 8); print $0; }') )
 
-for i in "${!FIELDSARR[@]}"; do
-	if [[ "${FIELDSARR[$i]}" = "SSID" ]]; then
-		SSID_POS="${i}";
-	fi
-done
-
-let AWKSSIDPOS=$SSID_POS+1
 
 CHENTRY=$(echo -e "$TOGGLE\nmanual\n$LIST" | uniq -u | rofi -dmenu -p "Wi-Fi SSID: " -lines "$LINENUM" -a "$HIGHLINE" -location "$POSITION" -yoffset "$YOFF" -xoffset "$XOFF" -font "$FONT" -width -"$RWIDTH")
 #echo "$CHENTRY"
-CHSSID=$(echo "$CHENTRY" | sed  's/\s\{2,\}/\|/g' | awk -F "|" '{print $'$AWKSSIDPOS'}')
+CHSSID=$(echo "$CHENTRY" | sed  's/\s\{2,\}/\|/g' | awk -F "|" '{print $1}')
 #echo "$CHSSID"
 
 # If the user inputs "manual" as their SSID in the start window, it will bring them to this screen

--- a/rofi-wifi-menu.sh
+++ b/rofi-wifi-menu.sh
@@ -29,7 +29,7 @@ KNOWNCON=$(nmcli connection show)
 # Really janky way of telling if there is currently a connection
 CONSTATE=$(nmcli -fields WIFI g)
 
-CURRSSID=$(iwgetid -r)
+CURRSSID=$(LANGUAGE=C nmcli -t -f active,ssid dev wifi | awk -F: '$1 ~ /^yes/ {print $2}')
 
 if [[ ! -z $CURRSSID ]]; then
 	HIGHLINE=$(echo  "$(echo "$LIST" | awk -F "[  ]{2,}" '{print $1}' | grep -Fxn -m 1 "$CURRSSID" | awk -F ":" '{print $1}') + 1" | bc )

--- a/rofi-wifi-menu.sh
+++ b/rofi-wifi-menu.sh
@@ -12,7 +12,7 @@ XOFF=0
 FONT="DejaVu Sans Mono 8"
 
 if [ -r "$DIR/config" ]; then
-	source ./config
+	source "$DIR/config"
 elif [ -r "$HOME/.config/rofi/wifi" ]; then
 	source "$HOME/.config/rofi/wifi"
 else

--- a/rofi-wifi-menu.sh
+++ b/rofi-wifi-menu.sh
@@ -32,7 +32,7 @@ CONSTATE=$(nmcli -fields WIFI g)
 CURRSSID=$(iwgetid -r)
 
 if [[ ! -z $CURRSSID ]]; then
-	HIGHLINE=$(echo  "$(echo "$LIST" | awk -F "[  ]{2,}" '{print $1}' | grep -Fxn -m 1 "$CURRSSID" | awk -F ":" '{print $1}') + 1" | bc ) 
+	HIGHLINE=$(echo  "$(echo "$LIST" | awk -F "[  ]{2,}" '{print $1}' | grep -Fxn -m 1 "$CURRSSID" | awk -F ":" '{print $1}') + 1" | bc )
 fi
 
 # HOPEFULLY you won't need this as often as I do
@@ -71,7 +71,7 @@ if [ "$CHENTRY" = "manual" ] ; then
 	MSSID=$(echo "enter the SSID of the network (SSID,password)" | rofi -dmenu -p "Manual Entry: " -font "$FONT" -lines 1)
 	# Separating the password from the entered string
 	MPASS=$(echo "$MSSID" | awk -F "," '{print $2}')
-	
+
 	#echo "$MSSID"
 	#echo "$MPASS"
 
@@ -87,7 +87,7 @@ elif [ "$CHENTRY" = "toggle on" ]; then
 
 elif [ "$CHENTRY" = "toggle off" ]; then
 	nmcli radio wifi off
-	
+
 else
 
 	# If the connection is already in use, then this will still be able to get the SSID


### PR DESCRIPTION
This PR bundle up a few tweaks:
- replacing `iwgetid` with `nmcli`, one less dependency
- fix error `cat: ./config: No such file or directory` by removing dead code, configuration loading has changed with merging of #8
- fix issue #6 
- removing useless spaces at the end of lines

I can split this up in separate PRs if need be.