### PR TITLE
Add set -euo pipefail to the top of the script

### DIFF
--- a/rofi-wifi-menu.sh
+++ b/rofi-wifi-menu.sh
@@ -2,6 +2,7 @@
 
 # Starts a scan of available broadcasting SSIDs
 # nmcli dev wifi rescan
+set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 


### PR DESCRIPTION
This fixes a few user experience issues I encountered when first using the script, by making the script fail immediately on things like pressing esc in rofi instead of making nmcli throw an error or do the wrong thing on empty input